### PR TITLE
maint: wire faer QR solver, fix formatting, add __pycache__ gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 # Crosslink caches in subcrates
 **/.crosslink/
+
+# Python
+__pycache__/

--- a/ferrolearn-cluster/tests/oracle_tests.rs
+++ b/ferrolearn-cluster/tests/oracle_tests.rs
@@ -133,8 +133,7 @@ fn test_dbscan_oracle() {
     let sklearn_n_clusters = fixture["expected"]["n_clusters"].as_u64().unwrap() as usize;
     let sklearn_n_noise = fixture["expected"]["n_noise"].as_u64().unwrap() as usize;
 
-    let model = ferrolearn_cluster::DBSCAN::<f64>::new(1.5)
-        .with_min_samples(5);
+    let model = ferrolearn_cluster::DBSCAN::<f64>::new(1.5).with_min_samples(5);
     let fitted = model.fit(&x, &()).unwrap();
 
     let labels = fitted.labels();

--- a/ferrolearn-decomp/tests/oracle_tests.rs
+++ b/ferrolearn-decomp/tests/oracle_tests.rs
@@ -65,7 +65,10 @@ fn test_pca_oracle() {
     // Mean should match sklearn's closely.
     let mean = fitted.mean();
     for (i, (&actual, &expected)) in mean.iter().zip(sklearn_mean.iter()).enumerate() {
-        assert_relative_eq!(actual, expected, epsilon = 1e-6,
+        assert_relative_eq!(
+            actual,
+            expected,
+            epsilon = 1e-6,
             // Custom message on failure
         );
         let _ = i; // suppress unused warning
@@ -207,7 +210,12 @@ fn test_nmf_oracle() {
     // L2 norm to sklearn's.
     for j in 0..w.ncols() {
         let our_norm: f64 = w.column(j).iter().map(|v| v * v).sum::<f64>().sqrt();
-        let sk_norm: f64 = sklearn_w.column(j).iter().map(|v| v * v).sum::<f64>().sqrt();
+        let sk_norm: f64 = sklearn_w
+            .column(j)
+            .iter()
+            .map(|v| v * v)
+            .sum::<f64>()
+            .sqrt();
         let ratio = our_norm / sk_norm.max(1e-10);
         assert!(
             (0.1..10.0).contains(&ratio),

--- a/ferrolearn-linear/src/linalg.rs
+++ b/ferrolearn-linear/src/linalg.rs
@@ -38,9 +38,6 @@ pub(crate) fn solve_lstsq<F: Float + Send + Sync + 'static>(
 ) -> Result<Array1<F>, FerroError> {
     let (n_samples, n_features) = x.dim();
 
-    // Try the faer path for f64.
-    // Since we are generic over F, we need to use a runtime check.
-    // For now, convert through f64 regardless.
     if n_samples < n_features {
         return Err(FerroError::InsufficientSamples {
             required: n_features,
@@ -49,9 +46,16 @@ pub(crate) fn solve_lstsq<F: Float + Send + Sync + 'static>(
         });
     }
 
-    // Normal equations approach: (X^T X) w = X^T y
-    // This is numerically less stable than QR but works for any Float type.
-    // We use the Householder QR manually via ndarray operations.
+    // Use faer QR decomposition for f64 (higher numerical accuracy).
+    if std::any::TypeId::of::<F>() == std::any::TypeId::of::<f64>() {
+        // Convert to f64 arrays, solve with faer, convert back.
+        let x_f64 = x.mapv(|v| v.to_f64().unwrap());
+        let y_f64 = y.mapv(|v| v.to_f64().unwrap());
+        let result = solve_lstsq_faer(&x_f64, &y_f64)?;
+        return Ok(result.mapv(|v| F::from(v).unwrap()));
+    }
+
+    // Fallback for f32 and other float types: normal equations.
     solve_normal_equations(x, y)
 }
 
@@ -229,7 +233,6 @@ pub(crate) fn solve_ridge<F: Float + Send + Sync + 'static>(
 /// Solve `X^T X w = X^T y` using faer QR decomposition (f64 only).
 ///
 /// This provides the highest numerical accuracy for f64 data.
-#[allow(dead_code)]
 pub(crate) fn solve_lstsq_faer(
     x: &Array2<f64>,
     y: &Array1<f64>,

--- a/ferrolearn-neighbors/tests/oracle_tests.rs
+++ b/ferrolearn-neighbors/tests/oracle_tests.rs
@@ -63,8 +63,7 @@ fn test_kneighbors_classifier_oracle() {
         .collect();
     let sklearn_accuracy = fixture["expected"]["accuracy"].as_f64().unwrap();
 
-    let model = ferrolearn_neighbors::KNeighborsClassifier::<f64>::new()
-        .with_n_neighbors(5);
+    let model = ferrolearn_neighbors::KNeighborsClassifier::<f64>::new().with_n_neighbors(5);
     let fitted = model.fit(&x, &y).unwrap();
     let preds = fitted.predict(&x).unwrap();
 
@@ -106,8 +105,7 @@ fn test_kneighbors_regressor_oracle() {
     let expected_preds = json_to_array1_f64(&fixture["expected"]["predictions"]);
     let sklearn_r2 = fixture["expected"]["r2"].as_f64().unwrap();
 
-    let model = ferrolearn_neighbors::KNeighborsRegressor::<f64>::new()
-        .with_n_neighbors(5);
+    let model = ferrolearn_neighbors::KNeighborsRegressor::<f64>::new().with_n_neighbors(5);
     let fitted = model.fit(&x, &y).unwrap();
     let preds = fitted.predict(&x).unwrap();
 
@@ -125,7 +123,11 @@ fn test_kneighbors_regressor_oracle() {
 
     // R² should be close to sklearn's.
     let y_mean = y.mean().unwrap();
-    let ss_res: f64 = preds.iter().zip(y.iter()).map(|(p, t)| (t - p).powi(2)).sum();
+    let ss_res: f64 = preds
+        .iter()
+        .zip(y.iter())
+        .map(|(p, t)| (t - p).powi(2))
+        .sum();
     let ss_tot: f64 = y.iter().map(|t| (t - y_mean).powi(2)).sum();
     let r2 = 1.0 - ss_res / ss_tot;
 

--- a/ferrolearn-tree/tests/oracle_tests.rs
+++ b/ferrolearn-tree/tests/oracle_tests.rs
@@ -61,8 +61,7 @@ fn test_decision_tree_classifier_oracle() {
 
     let sklearn_accuracy = fixture["expected"]["accuracy"].as_f64().unwrap();
 
-    let model = ferrolearn_tree::DecisionTreeClassifier::<f64>::new()
-        .with_max_depth(Some(3));
+    let model = ferrolearn_tree::DecisionTreeClassifier::<f64>::new().with_max_depth(Some(3));
     let fitted = model.fit(&x, &y).unwrap();
     let preds = fitted.predict(&x).unwrap();
 
@@ -100,14 +99,17 @@ fn test_decision_tree_regressor_oracle() {
 
     let sklearn_r2 = fixture["expected"]["r2"].as_f64().unwrap();
 
-    let model = ferrolearn_tree::DecisionTreeRegressor::<f64>::new()
-        .with_max_depth(Some(4));
+    let model = ferrolearn_tree::DecisionTreeRegressor::<f64>::new().with_max_depth(Some(4));
     let fitted = model.fit(&x, &y).unwrap();
     let preds = fitted.predict(&x).unwrap();
 
     // Compute R².
     let y_mean = y.mean().unwrap();
-    let ss_res: f64 = preds.iter().zip(y.iter()).map(|(p, t)| (t - p).powi(2)).sum();
+    let ss_res: f64 = preds
+        .iter()
+        .zip(y.iter())
+        .map(|(p, t)| (t - p).powi(2))
+        .sum();
     let ss_tot: f64 = y.iter().map(|t| (t - y_mean).powi(2)).sum();
     let r2 = 1.0 - ss_res / ss_tot;
 
@@ -186,7 +188,11 @@ fn test_random_forest_regressor_oracle() {
     let preds = fitted.predict(&x).unwrap();
 
     let y_mean = y.mean().unwrap();
-    let ss_res: f64 = preds.iter().zip(y.iter()).map(|(p, t)| (t - p).powi(2)).sum();
+    let ss_res: f64 = preds
+        .iter()
+        .zip(y.iter())
+        .map(|(p, t)| (t - p).powi(2))
+        .sum();
     let ss_tot: f64 = y.iter().map(|t| (t - y_mean).powi(2)).sum();
     let r2 = 1.0 - ss_res / ss_tot;
 
@@ -210,9 +216,10 @@ fn test_random_forest_regressor_oracle() {
 
 #[test]
 fn test_gradient_boosting_classifier_oracle() {
-    let fixture: serde_json::Value =
-        serde_json::from_str(include_str!("../../fixtures/gradient_boosting_classifier.json"))
-            .unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "../../fixtures/gradient_boosting_classifier.json"
+    ))
+    .unwrap();
 
     let x = json_to_array2(&fixture["input"]["X"]);
     let y = json_to_labels(&fixture["input"]["y"]);
@@ -250,9 +257,10 @@ fn test_gradient_boosting_classifier_oracle() {
 
 #[test]
 fn test_gradient_boosting_regressor_oracle() {
-    let fixture: serde_json::Value =
-        serde_json::from_str(include_str!("../../fixtures/gradient_boosting_regressor.json"))
-            .unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "../../fixtures/gradient_boosting_regressor.json"
+    ))
+    .unwrap();
 
     let x = json_to_array2(&fixture["input"]["X"]);
     let y = json_to_array1_f64(&fixture["input"]["y"]);
@@ -268,7 +276,11 @@ fn test_gradient_boosting_regressor_oracle() {
     let preds = fitted.predict(&x).unwrap();
 
     let y_mean = y.mean().unwrap();
-    let ss_res: f64 = preds.iter().zip(y.iter()).map(|(p, t)| (t - p).powi(2)).sum();
+    let ss_res: f64 = preds
+        .iter()
+        .zip(y.iter())
+        .map(|(p, t)| (t - p).powi(2))
+        .sum();
     let ss_tot: f64 = y.iter().map(|t| (t - y_mean).powi(2)).sum();
     let r2 = 1.0 - ss_res / ss_tot;
 


### PR DESCRIPTION
## Summary

- Wire the unused `solve_lstsq_faer` (faer QR decomposition) into the generic `solve_lstsq` path for f64 data, providing higher numerical accuracy than normal equations
- Remove `#[allow(dead_code)]` on now-used `solve_lstsq_faer`
- Fix `rustfmt` formatting in 4 oracle test files
- Add `__pycache__/` to `.gitignore`

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace` — 1,468 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)