### PR TITLE
feat: formal verification infrastructure (Kani, proptest, sklearn equivalence, trybuild)

### DIFF
--- a/ferrolearn-metrics/src/regression.rs
+++ b/ferrolearn-metrics/src/regression.rs
@@ -242,6 +242,13 @@ where
 ///
 /// `MAPE = (1/n) * sum |( y_true - y_pred ) / y_true| * 100`
 ///
+/// **Convention note:** This function returns MAPE as a **percentage** (multiplied
+/// by 100), so perfect predictions yield 0.0 and predictions that are off by 10%
+/// on average yield 10.0. This differs from scikit-learn's
+/// `mean_absolute_percentage_error`, which returns a **fraction** (not multiplied
+/// by 100), where the same 10% error would be 0.1. Divide by 100 to convert to
+/// the sklearn convention.
+///
 /// Note: samples where `y_true == 0` are skipped to avoid division by zero.
 /// If all `y_true` values are zero, `MAPE` is returned as `F::infinity()`.
 ///


### PR DESCRIPTION
## Summary

Adds a comprehensive formal verification and correctness infrastructure across the ferrolearn workspace, implementing the design doc's correctness stack (Sections 20.1-20.6).

- **36 Kani proof harnesses** for metric output ranges and sparse matrix structural invariants
- **51 proptest property-based tests** across 8 crates verifying mathematical invariants
- **44 sklearn statistical equivalence tests** with 24 JSON reference fixtures
- **4 trybuild compile-fail tests** proving Fit/Predict type-system safety guarantees
- **Type-system documentation** on Fit/Predict/Transform traits
- **MAPE convention note** documenting the percentage vs fraction difference with sklearn

## Changes

### Kani proof harnesses (Issues #7, #8)
- `ferrolearn-metrics/src/{classification,regression,clustering}.rs` — 15 harnesses proving output range bounds and NaN safety
- `ferrolearn-sparse/src/{csr,csc}.rs` — 22 harnesses proving structural invariants (indptr, column bounds, monotonicity)

### Proptest invariants (Issue #11)
- 51 property tests across 8 crates: coefficient dimensions, proba normalization, inverse_transform roundtrips, label validity, orthonormality, metric identity properties

### sklearn equivalence suite (Issue #9)
- `scripts/generate_sklearn_fixtures.py` + 24 JSON fixtures
- 44 Rust integration tests comparing against sklearn within documented tolerances
- Documented divergences with root causes (iterative solver paths, RNG differences, MAPE convention)

### Type-system proofs (Issue #10)
- Trait documentation explaining compile-time safety guarantees
- 4 trybuild compile-fail tests (predict on unfitted model = compile error)

### Docs
- MAPE convention note: ferrolearn returns percentage (x100), sklearn returns fraction

## Test plan
- [x] `cargo test --workspace` — all tests pass, zero failures
- [x] No modifications to existing source logic (only docs, tests, and dev-dependencies)

Closes #7, closes #8, closes #9, closes #10, closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)