### PR TITLE
feat: formal verification, MAPE docs, and criterion benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +183,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +250,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -461,6 +573,24 @@ dependencies = [
  "num-traits",
  "proptest",
  "serde_json",
+]
+
+[[package]]
+name = "ferrolearn-bench"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "ferrolearn-bayes",
+ "ferrolearn-cluster",
+ "ferrolearn-core",
+ "ferrolearn-datasets",
+ "ferrolearn-decomp",
+ "ferrolearn-linear",
+ "ferrolearn-metrics",
+ "ferrolearn-neighbors",
+ "ferrolearn-preprocess",
+ "ferrolearn-tree",
+ "ndarray",
 ]
 
 [[package]]
@@ -934,10 +1064,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kani-verifier"
@@ -1394,6 +1554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,6 +1628,34 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1786,6 +1980,18 @@ name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-automata"
@@ -2119,6 +2325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2517,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2593,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "ferrolearn-datasets",
     "ferrolearn-io",
     "ferrolearn-python",
+    "ferrolearn-bench",
 ]
 resolver = "3"
 

--- a/ferrolearn-bench/Cargo.toml
+++ b/ferrolearn-bench/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "ferrolearn-bench"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+ferrolearn-core.workspace = true
+ferrolearn-linear.workspace = true
+ferrolearn-tree.workspace = true
+ferrolearn-neighbors.workspace = true
+ferrolearn-bayes.workspace = true
+ferrolearn-cluster.workspace = true
+ferrolearn-decomp.workspace = true
+ferrolearn-preprocess.workspace = true
+ferrolearn-metrics.workspace = true
+ferrolearn-datasets.workspace = true
+ndarray.workspace = true
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "regressors"
+harness = false
+
+[[bench]]
+name = "classifiers"
+harness = false
+
+[[bench]]
+name = "transformers"
+harness = false
+
+[[bench]]
+name = "clusterers"
+harness = false
+
+[[bench]]
+name = "metrics"
+harness = false

--- a/ferrolearn-bench/benches/classifiers.rs
+++ b/ferrolearn-bench/benches/classifiers.rs
@@ -1,0 +1,102 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ferrolearn_bench::{SIZES, classification_data};
+use ferrolearn_bayes::GaussianNB;
+use ferrolearn_core::{Fit, Predict};
+use ferrolearn_linear::LogisticRegression;
+use ferrolearn_neighbors::KNeighborsClassifier;
+use ferrolearn_tree::{DecisionTreeClassifier, RandomForestClassifier};
+
+fn bench_logistic_regression(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LogisticRegression");
+    group.sample_size(10);
+    for &(label, n, p) in SIZES {
+        let (x, y) = classification_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| LogisticRegression::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = LogisticRegression::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_decision_tree(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DecisionTreeClassifier");
+    for &(label, n, p) in SIZES {
+        let (x, y) = classification_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| DecisionTreeClassifier::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = DecisionTreeClassifier::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_random_forest(c: &mut Criterion) {
+    let mut group = c.benchmark_group("RandomForestClassifier");
+    group.sample_size(10);
+    for &(label, n, p) in SIZES {
+        let (x, y) = classification_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| {
+                RandomForestClassifier::<f64>::new()
+                    .with_random_state(42)
+                    .fit(&x, &y)
+                    .unwrap()
+            });
+        });
+        let fitted = RandomForestClassifier::<f64>::new()
+            .with_random_state(42)
+            .fit(&x, &y)
+            .unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_knn(c: &mut Criterion) {
+    let mut group = c.benchmark_group("KNeighborsClassifier");
+    for &(label, n, p) in SIZES {
+        let (x, y) = classification_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| KNeighborsClassifier::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = KNeighborsClassifier::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_gaussian_nb(c: &mut Criterion) {
+    let mut group = c.benchmark_group("GaussianNB");
+    for &(label, n, p) in SIZES {
+        let (x, y) = classification_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| GaussianNB::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = GaussianNB::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_logistic_regression,
+    bench_decision_tree,
+    bench_random_forest,
+    bench_knn,
+    bench_gaussian_nb,
+);
+criterion_main!(benches);

--- a/ferrolearn-bench/benches/clusterers.rs
+++ b/ferrolearn-bench/benches/clusterers.rs
@@ -1,0 +1,33 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ferrolearn_bench::{SIZES, clustering_data};
+use ferrolearn_cluster::KMeans;
+use ferrolearn_core::{Fit, Predict};
+
+fn bench_kmeans(c: &mut Criterion) {
+    let mut group = c.benchmark_group("KMeans");
+    group.sample_size(10);
+    for &(label, n, p) in SIZES {
+        let (x, _) = clustering_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| {
+                KMeans::<f64>::new(8)
+                    .with_random_state(42)
+                    .with_n_init(3)
+                    .fit(&x, &())
+                    .unwrap()
+            });
+        });
+        let fitted = KMeans::<f64>::new(8)
+            .with_random_state(42)
+            .with_n_init(3)
+            .fit(&x, &())
+            .unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_kmeans);
+criterion_main!(benches);

--- a/ferrolearn-bench/benches/metrics.rs
+++ b/ferrolearn-bench/benches/metrics.rs
@@ -1,0 +1,75 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ferrolearn_metrics::{classification, regression};
+use ndarray::Array1;
+
+const METRIC_SIZES: &[(&str, usize)] = &[
+    ("1K", 1_000),
+    ("10K", 10_000),
+    ("100K", 100_000),
+];
+
+fn make_regression_predictions(n: usize) -> (Array1<f64>, Array1<f64>) {
+    let y_true = Array1::from_iter((0..n).map(|i| i as f64 * 0.1));
+    let y_pred = Array1::from_iter((0..n).map(|i| i as f64 * 0.1 + 0.01));
+    (y_true, y_pred)
+}
+
+fn make_classification_predictions(n: usize) -> (Array1<usize>, Array1<usize>) {
+    let y_true = Array1::from_iter((0..n).map(|i| i % 3));
+    let y_pred = Array1::from_iter((0..n).map(|i| (i + 1) % 3));
+    (y_true, y_pred)
+}
+
+fn bench_accuracy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("accuracy_score");
+    for &(label, n) in METRIC_SIZES {
+        let (y_true, y_pred) = make_classification_predictions(n);
+        group.bench_with_input(BenchmarkId::from_parameter(label), &(), |b, _| {
+            b.iter(|| classification::accuracy_score(&y_true, &y_pred).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_f1(c: &mut Criterion) {
+    let mut group = c.benchmark_group("f1_score");
+    for &(label, n) in METRIC_SIZES {
+        let (y_true, y_pred) = make_classification_predictions(n);
+        group.bench_with_input(BenchmarkId::from_parameter(label), &(), |b, _| {
+            b.iter(|| {
+                classification::f1_score(
+                    &y_true,
+                    &y_pred,
+                    classification::Average::Macro,
+                )
+                .unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_mse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mean_squared_error");
+    for &(label, n) in METRIC_SIZES {
+        let (y_true, y_pred) = make_regression_predictions(n);
+        group.bench_with_input(BenchmarkId::from_parameter(label), &(), |b, _| {
+            b.iter(|| regression::mean_squared_error(&y_true, &y_pred).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_r2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("r2_score");
+    for &(label, n) in METRIC_SIZES {
+        let (y_true, y_pred) = make_regression_predictions(n);
+        group.bench_with_input(BenchmarkId::from_parameter(label), &(), |b, _| {
+            b.iter(|| regression::r2_score(&y_true, &y_pred).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_accuracy, bench_f1, bench_mse, bench_r2);
+criterion_main!(benches);

--- a/ferrolearn-bench/benches/regressors.rs
+++ b/ferrolearn-bench/benches/regressors.rs
@@ -1,0 +1,77 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ferrolearn_bench::{SIZES, regression_data};
+use ferrolearn_core::{Fit, Predict};
+use ferrolearn_linear::{
+    ElasticNet, Lasso, LinearRegression, Ridge,
+};
+
+fn bench_linear_regression(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LinearRegression");
+    for &(label, n, p) in SIZES {
+        let (x, y) = regression_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| LinearRegression::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = LinearRegression::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_ridge(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Ridge");
+    for &(label, n, p) in SIZES {
+        let (x, y) = regression_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| Ridge::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = Ridge::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_lasso(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Lasso");
+    group.sample_size(10);
+    for &(label, n, p) in SIZES {
+        let (x, y) = regression_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| Lasso::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = Lasso::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_elastic_net(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ElasticNet");
+    group.sample_size(10);
+    for &(label, n, p) in SIZES {
+        let (x, y) = regression_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| ElasticNet::<f64>::new().fit(&x, &y).unwrap());
+        });
+        let fitted = ElasticNet::<f64>::new().fit(&x, &y).unwrap();
+        group.bench_with_input(BenchmarkId::new("predict", label), &(), |b, _| {
+            b.iter(|| fitted.predict(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_linear_regression,
+    bench_ridge,
+    bench_lasso,
+    bench_elastic_net,
+);
+criterion_main!(benches);

--- a/ferrolearn-bench/benches/transformers.rs
+++ b/ferrolearn-bench/benches/transformers.rs
@@ -1,0 +1,40 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ferrolearn_bench::{SIZES, regression_data};
+use ferrolearn_core::{Fit, Transform};
+use ferrolearn_decomp::PCA;
+use ferrolearn_preprocess::StandardScaler;
+
+fn bench_standard_scaler(c: &mut Criterion) {
+    let mut group = c.benchmark_group("StandardScaler");
+    for &(label, n, p) in SIZES {
+        let (x, _) = regression_data(n, p);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| StandardScaler::<f64>::new().fit(&x, &()).unwrap());
+        });
+        let fitted = StandardScaler::<f64>::new().fit(&x, &()).unwrap();
+        group.bench_with_input(BenchmarkId::new("transform", label), &(), |b, _| {
+            b.iter(|| fitted.transform(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_pca(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PCA");
+    group.sample_size(10);
+    for &(label, n, p) in SIZES {
+        let (x, _) = regression_data(n, p);
+        let n_components = p.min(10);
+        group.bench_with_input(BenchmarkId::new("fit", label), &(), |b, _| {
+            b.iter(|| PCA::<f64>::new(n_components).fit(&x, &()).unwrap());
+        });
+        let fitted = PCA::<f64>::new(n_components).fit(&x, &()).unwrap();
+        group.bench_with_input(BenchmarkId::new("transform", label), &(), |b, _| {
+            b.iter(|| fitted.transform(&x).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_standard_scaler, bench_pca);
+criterion_main!(benches);

--- a/ferrolearn-bench/src/lib.rs
+++ b/ferrolearn-bench/src/lib.rs
@@ -1,0 +1,28 @@
+//! Shared data generation helpers for ferrolearn benchmarks.
+
+use ferrolearn_datasets::generators::{make_blobs, make_classification, make_regression};
+use ndarray::{Array1, Array2};
+
+/// Dataset sizes for benchmarking.
+pub const SIZES: &[(&str, usize, usize)] = &[
+    ("tiny_50x5", 50, 5),
+    ("small_1Kx10", 1_000, 10),
+    ("medium_10Kx100", 10_000, 100),
+];
+
+/// Generate regression data (X, y) for a given size.
+pub fn regression_data(n_samples: usize, n_features: usize) -> (Array2<f64>, Array1<f64>) {
+    let n_informative = n_features.min(n_features);
+    make_regression::<f64>(n_samples, n_features, n_informative, 0.1, Some(42)).unwrap()
+}
+
+/// Generate classification data (X, y) for a given size.
+pub fn classification_data(n_samples: usize, n_features: usize) -> (Array2<f64>, Array1<usize>) {
+    let n_classes = 2;
+    make_classification::<f64>(n_samples, n_features, n_classes, Some(42)).unwrap()
+}
+
+/// Generate clustering data (X, y) for a given size.
+pub fn clustering_data(n_samples: usize, n_features: usize) -> (Array2<f64>, Array1<usize>) {
+    make_blobs::<f64>(n_samples, n_features, 8, 1.0, Some(42)).unwrap()
+}

--- a/scripts/benchmark_sklearn.py
+++ b/scripts/benchmark_sklearn.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Benchmark sklearn models for comparison with ferrolearn criterion results.
+
+Outputs JSON to stdout with median times in seconds for each (model, size, operation).
+Run: python3 scripts/benchmark_sklearn.py
+"""
+
+import json
+import sys
+import timeit
+
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.datasets import make_blobs, make_classification, make_regression
+from sklearn.decomposition import PCA
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import (
+    ElasticNet,
+    Lasso,
+    LinearRegression,
+    LogisticRegression,
+    Ridge,
+)
+from sklearn.naive_bayes import GaussianNB
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.preprocessing import StandardScaler
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    mean_squared_error,
+    r2_score,
+)
+
+SIZES = [
+    ("tiny_50x5", 50, 5),
+    ("small_1Kx10", 1_000, 10),
+    ("medium_10Kx100", 10_000, 100),
+]
+
+METRIC_SIZES = [
+    ("1K", 1_000),
+    ("10K", 10_000),
+    ("100K", 100_000),
+]
+
+
+def time_fn(fn, number=None):
+    """Return median time in seconds over multiple runs."""
+    if number is None:
+        # Auto-calibrate: run once to estimate, then pick a count
+        t0 = timeit.timeit(fn, number=1)
+        if t0 > 1.0:
+            number = 3
+        elif t0 > 0.1:
+            number = 10
+        elif t0 > 0.01:
+            number = 50
+        else:
+            number = 200
+
+    times = []
+    for _ in range(number):
+        t = timeit.timeit(fn, number=1)
+        times.append(t)
+    times.sort()
+    return times[len(times) // 2]  # median
+
+
+def bench_regressors():
+    results = {}
+    models = {
+        "LinearRegression": lambda: LinearRegression(),
+        "Ridge": lambda: Ridge(),
+        "Lasso": lambda: Lasso(max_iter=1000),
+        "ElasticNet": lambda: ElasticNet(max_iter=1000),
+    }
+    for name, make_model in models.items():
+        for label, n, p in SIZES:
+            X, y = make_regression(n_samples=n, n_features=p, n_informative=p, noise=0.1, random_state=42)
+            model = make_model()
+            fit_time = time_fn(lambda: make_model().fit(X, y))
+            fitted = model.fit(X, y)
+            predict_time = time_fn(lambda: fitted.predict(X))
+            results[f"{name}/fit/{label}"] = fit_time
+            results[f"{name}/predict/{label}"] = predict_time
+            print(f"  {name:30s} {label:20s} fit={fit_time*1000:10.3f}ms  predict={predict_time*1000:10.3f}ms", file=sys.stderr)
+    return results
+
+
+def bench_classifiers():
+    results = {}
+    models = {
+        "LogisticRegression": lambda: LogisticRegression(max_iter=1000),
+        "DecisionTreeClassifier": lambda: DecisionTreeClassifier(),
+        "RandomForestClassifier": lambda: RandomForestClassifier(n_estimators=100, random_state=42),
+        "KNeighborsClassifier": lambda: KNeighborsClassifier(n_neighbors=5),
+        "GaussianNB": lambda: GaussianNB(),
+    }
+    for name, make_model in models.items():
+        for label, n, p in SIZES:
+            X, y = make_classification(n_samples=n, n_features=p, n_informative=max(2, p // 2), random_state=42)
+            model = make_model()
+            fit_time = time_fn(lambda: make_model().fit(X, y))
+            fitted = model.fit(X, y)
+            predict_time = time_fn(lambda: fitted.predict(X))
+            results[f"{name}/fit/{label}"] = fit_time
+            results[f"{name}/predict/{label}"] = predict_time
+            print(f"  {name:30s} {label:20s} fit={fit_time*1000:10.3f}ms  predict={predict_time*1000:10.3f}ms", file=sys.stderr)
+    return results
+
+
+def bench_transformers():
+    results = {}
+    for label, n, p in SIZES:
+        X, _ = make_regression(n_samples=n, n_features=p, random_state=42)
+
+        # StandardScaler
+        fit_time = time_fn(lambda: StandardScaler().fit(X))
+        fitted = StandardScaler().fit(X)
+        transform_time = time_fn(lambda: fitted.transform(X))
+        results[f"StandardScaler/fit/{label}"] = fit_time
+        results[f"StandardScaler/transform/{label}"] = transform_time
+        print(f"  {'StandardScaler':30s} {label:20s} fit={fit_time*1000:10.3f}ms  transform={transform_time*1000:10.3f}ms", file=sys.stderr)
+
+        # PCA
+        nc = min(p, 10)
+        fit_time = time_fn(lambda: PCA(n_components=nc).fit(X))
+        fitted = PCA(n_components=nc).fit(X)
+        transform_time = time_fn(lambda: fitted.transform(X))
+        results[f"PCA/fit/{label}"] = fit_time
+        results[f"PCA/transform/{label}"] = transform_time
+        print(f"  {'PCA':30s} {label:20s} fit={fit_time*1000:10.3f}ms  transform={transform_time*1000:10.3f}ms", file=sys.stderr)
+
+    return results
+
+
+def bench_clusterers():
+    results = {}
+    for label, n, p in SIZES:
+        X, _ = make_blobs(n_samples=n, n_features=p, centers=8, random_state=42)
+        fit_time = time_fn(lambda: KMeans(n_clusters=8, n_init=3, random_state=42).fit(X))
+        fitted = KMeans(n_clusters=8, n_init=3, random_state=42).fit(X)
+        predict_time = time_fn(lambda: fitted.predict(X))
+        results[f"KMeans/fit/{label}"] = fit_time
+        results[f"KMeans/predict/{label}"] = predict_time
+        print(f"  {'KMeans':30s} {label:20s} fit={fit_time*1000:10.3f}ms  predict={predict_time*1000:10.3f}ms", file=sys.stderr)
+    return results
+
+
+def bench_metrics():
+    results = {}
+    for label, n in METRIC_SIZES:
+        y_true_cls = np.array([i % 3 for i in range(n)])
+        y_pred_cls = np.array([(i + 1) % 3 for i in range(n)])
+        y_true_reg = np.arange(n, dtype=np.float64) * 0.1
+        y_pred_reg = y_true_reg + 0.01
+
+        t = time_fn(lambda: accuracy_score(y_true_cls, y_pred_cls))
+        results[f"accuracy_score/{label}"] = t
+        print(f"  {'accuracy_score':30s} {label:20s} {t*1000:10.3f}ms", file=sys.stderr)
+
+        t = time_fn(lambda: f1_score(y_true_cls, y_pred_cls, average="macro"))
+        results[f"f1_score/{label}"] = t
+        print(f"  {'f1_score':30s} {label:20s} {t*1000:10.3f}ms", file=sys.stderr)
+
+        t = time_fn(lambda: mean_squared_error(y_true_reg, y_pred_reg))
+        results[f"mean_squared_error/{label}"] = t
+        print(f"  {'mean_squared_error':30s} {label:20s} {t*1000:10.3f}ms", file=sys.stderr)
+
+        t = time_fn(lambda: r2_score(y_true_reg, y_pred_reg))
+        results[f"r2_score/{label}"] = t
+        print(f"  {'r2_score':30s} {label:20s} {t*1000:10.3f}ms", file=sys.stderr)
+
+    return results
+
+
+def main():
+    all_results = {}
+    print("Benchmarking regressors...", file=sys.stderr)
+    all_results.update(bench_regressors())
+    print("Benchmarking classifiers...", file=sys.stderr)
+    all_results.update(bench_classifiers())
+    print("Benchmarking transformers...", file=sys.stderr)
+    all_results.update(bench_transformers())
+    print("Benchmarking clusterers...", file=sys.stderr)
+    all_results.update(bench_clusterers())
+    print("Benchmarking metrics...", file=sys.stderr)
+    all_results.update(bench_metrics())
+
+    json.dump(all_results, sys.stdout, indent=2)
+    print(file=sys.stderr)
+    print(f"Done. {len(all_results)} benchmarks recorded.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Formal verification infrastructure**: 36 Kani proof harnesses, 51 proptest property tests, 44 sklearn equivalence tests, 4 trybuild compile-fail tests
- **MAPE convention note**: documents the percentage vs fraction difference with sklearn
- **Criterion benchmark suite**: 5 bench targets covering all 12 models + 4 metrics, plus a Python sklearn comparison script

## Changes

### Formal verification (Issues #7-#11)
- Kani harnesses for metric output ranges and sparse matrix structural invariants
- proptest harnesses across 8 crates for mathematical invariants
- 44 sklearn equivalence tests with 24 JSON reference fixtures
- trybuild compile-fail tests proving Fit/Predict type-system guarantees
- Type-system documentation on core traits

### Docs
- MAPE convention note: ferrolearn returns percentage (x100), sklearn returns fraction

### Benchmarks (Issue #14)
- `ferrolearn-bench/` crate with criterion benches for regressors, classifiers, transformers, clusterers, and metrics
- `scripts/benchmark_sklearn.py` for head-to-head comparison
- Dataset sizes: tiny (50x5), small (1Kx10), medium (10Kx100)
- Run with `cargo bench -p ferrolearn-bench`

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo bench -p ferrolearn-bench --bench metrics -- --quick` runs successfully
- [x] `cargo bench -p ferrolearn-bench --bench regressors -- --quick` runs successfully
- [x] `cargo check -p ferrolearn-bench --benches` clean

Closes #7, closes #8, closes #9, closes #10, closes #11, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)